### PR TITLE
Ajout de totaux 20 ans au tableau des résultats

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,8 @@
         <tr><th>Facture annuelle dans 20 ans (€)</th><td id="facturean20">-</td></tr>
         <tr><th>Prix du kWh dans 10 ans (€)</th><td id="kwh10ans">-</td></tr>
         <tr><th>Facture estimée dans 10 ans (€)</th><td id="facture10ans">-</td></tr>
+        <tr><th>Total 20 ans factures sans PV</th><td id="factotal20anssanspv">-</td></tr>
+        <tr><th>Total 20 ans factures avec PV</th><td id="factotal20ansavecpv">-</td></tr>
     </tbody>
   </table>
 </fieldset>


### PR DESCRIPTION
## Summary
- ajoute deux lignes pour afficher les totaux de factures sur 20 ans avec et sans PV

## Testing
- `npm test` *(échec : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_689990efb968832fbfbea700e767ed6e