### PR TITLE
Add 20-year cost calculations for PV savings

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,8 @@
         <tr><th>Facture annuelle (€)</th><td id="facturean">-</td></tr>
         <tr><th>Facture annuelle dans 10 ans (€)</th><td id="facturean10">-</td></tr>
         <tr><th>Facture annuelle dans 20 ans (€)</th><td id="facturean20">-</td></tr>
+        <tr><th>Facture totale sur 20 ans sans PV (€)</th><td id="factotal20anssanspv">-</td></tr>
+        <tr><th>Facture totale sur 20 ans avec PV (€)</th><td id="factotal20ansavecpv">-</td></tr>
         <tr><th>Prix du kWh dans 10 ans (€)</th><td id="kwh10ans">-</td></tr>
         <tr><th>Facture estimée dans 10 ans (€)</th><td id="facture10ans">-</td></tr>
     </tbody>

--- a/script.js
+++ b/script.js
@@ -72,6 +72,11 @@ document.getElementById("calculateIrrButton").addEventListener("click", async ()
     const kwh10ans = tarif * Math.pow(1 + haussekwh, 10);
     const facture10ans = facture * Math.pow(1 + haussekwh, 10);
 
+    const factotal20anssanspv = facturean * (Math.pow(1 + haussekwh, 20) - 1) / haussekwh;
+    const economies20ans = autoconsokwh * tarif * (Math.pow(1 + haussekwh, 20) - 1) / haussekwh;
+    const revente20ans = reventekwh * rachat * 20;
+    const factotal20ansavecpv = factotal20anssanspv - economies20ans - revente20ans;
+
     // 🔢 Production mensuelle (extraite du texte PVGIS)
     const moisNoms = ["Janvier","Février","Mars","Avril","Mai","Juin","Juillet","Août","Septembre","Octobre","Novembre","Décembre"];
     const prodMensuelle = [];
@@ -113,6 +118,8 @@ document.getElementById("calculateIrrButton").addEventListener("click", async ()
     document.getElementById("facturean").textContent = fr(facturean);
     document.getElementById("facturean10").textContent = fr(facturean10);
     document.getElementById("facturean20").textContent = fr(facturean20);
+    document.getElementById("factotal20anssanspv").textContent = fr(factotal20anssanspv);
+    document.getElementById("factotal20ansavecpv").textContent = fr(factotal20ansavecpv);
 
   } catch (e) {
     alert("Erreur lors du calcul. Vérifiez les données ou la connexion.");


### PR DESCRIPTION
## Summary
- Calculate total electricity cost over 20 years with and without solar PV
- Display 20-year totals in the results table

## Testing
- `node --check script.js`
- `node -e "const facturean=1200; const haussekwh=0.05; const autoconsokwh=3000; const reventekwh=1500; const tarif=0.23; const rachat=0.1788; const factotal20anssanspv = facturean*(Math.pow(1+haussekwh,20)-1)/haussekwh; const economies20ans = autoconsokwh*tarif*(Math.pow(1+haussekwh,20)-1)/haussekwh; const revente20ans = reventekwh*rachat*20; const factotal20ansavecpv = factotal20anssanspv - economies20ans - revente20ans; console.log({factotal20anssanspv, economies20ans, revente20ans, factotal20ansavecpv});"`


------
https://chatgpt.com/codex/tasks/task_e_689990f6d0e8832f8eba19fe51c319a2