### PR TITLE
Remove duplicate 20-year invoice rows from results table

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,8 +73,6 @@
         <tr><th>Facture totale sur 20 ans avec PV (€)</th><td id="factotal20ansavecpv">-</td></tr>
         <tr><th>Prix du kWh dans 10 ans (€)</th><td id="kwh10ans">-</td></tr>
         <tr><th>Facture estimée dans 10 ans (€)</th><td id="facture10ans">-</td></tr>
-        <tr><th>Total 20 ans factures sans PV</th><td id="factotal20anssanspv">-</td></tr>
-        <tr><th>Total 20 ans factures avec PV</th><td id="factotal20ansavecpv">-</td></tr>
     </tbody>
   </table>
 </fieldset>


### PR DESCRIPTION
## Summary
- remove redundant "Total 20 ans factures" rows to avoid duplicate IDs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689995ff6fb8832f9fd08df9df27f01b