### PR TITLE
Add 20-year savings and surplus revenue calculations

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,8 @@
         <tr><th>Facture annuelle dans 10 ans (€)</th><td id="facturean10">-</td></tr>
         <tr><th>Facture annuelle dans 20 ans (€)</th><td id="facturean20">-</td></tr>
         <tr><th>Facture totale sur 20 ans sans PV (€)</th><td id="factotal20anssanspv">-</td></tr>
+        <tr><th>Revente totale sur 20 ans (€)</th><td id="reventetotal20ans">-</td></tr>
+        <tr><th>Économie totale sur 20 ans (€)</th><td id="ecototal20ans">-</td></tr>
         <tr><th>Facture totale sur 20 ans avec PV (€)</th><td id="factotal20ansavecpv">-</td></tr>
         <tr><th>Prix du kWh dans 10 ans (€)</th><td id="kwh10ans">-</td></tr>
         <tr><th>Facture estimée dans 10 ans (€)</th><td id="facture10ans">-</td></tr>

--- a/script.js
+++ b/script.js
@@ -74,8 +74,9 @@ document.getElementById("calculateIrrButton").addEventListener("click", async ()
 
     const factotal20anssanspv = facturean * (Math.pow(1 + haussekwh, 20) - 1) / haussekwh;
     const economies20ans = autoconsokwh * tarif * (Math.pow(1 + haussekwh, 20) - 1) / haussekwh;
-    const revente20ans = reventekwh * rachat * 20;
-    const factotal20ansavecpv = factotal20anssanspv - economies20ans - revente20ans;
+    const reventetotal20ans = reventekwh * rachat * 20;
+    const ecototal20ans = economies20ans + reventetotal20ans;
+    const factotal20ansavecpv = factotal20anssanspv - ecototal20ans;
 
     // 🔢 Production mensuelle (extraite du texte PVGIS)
     const moisNoms = ["Janvier","Février","Mars","Avril","Mai","Juin","Juillet","Août","Septembre","Octobre","Novembre","Décembre"];
@@ -119,6 +120,8 @@ document.getElementById("calculateIrrButton").addEventListener("click", async ()
     document.getElementById("facturean10").textContent = fr(facturean10);
     document.getElementById("facturean20").textContent = fr(facturean20);
     document.getElementById("factotal20anssanspv").textContent = fr(factotal20anssanspv);
+    document.getElementById("reventetotal20ans").textContent = fr(reventetotal20ans);
+    document.getElementById("ecototal20ans").textContent = fr(ecototal20ans);
     document.getElementById("factotal20ansavecpv").textContent = fr(factotal20ansavecpv);
 
   } catch (e) {


### PR DESCRIPTION
## Summary
- compute and display total surplus revenue over 20 years (`reventetotal20ans`)
- compute and display overall 20-year savings including indexed self-consumption (`ecototal20ans`)
- adjust 20-year bill with PV to subtract these totals

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/etudepart/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689a07b84b04832fa4e8efcebfd6ac99