### PR TITLE
Split GPS coordinates into latitude and longitude fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,11 @@
 
 <fieldset>
   <legend>🔷 Données à saisir</legend>
-  <label>Coordonnées GPS (lat, lon)
-    <input type="text" id="gpsCoord" placeholder="ex : 14.6151, -61.0698">
+  <label>Latitude
+    <input type="text" id="latitude" placeholder="ex : 14.6151">
+  </label>
+  <label>Longitude
+    <input type="text" id="longitude" placeholder="ex : -61.0698">
   </label>
   <label>Orientation
     <select id="orientationIrr">

--- a/script.js
+++ b/script.js
@@ -11,10 +11,10 @@ document.getElementById("puissance").addEventListener("input", () => {
 });
 
 document.getElementById("calculateIrrButton").addEventListener("click", async () => {
-  const gpsRaw = document.getElementById("gpsCoord").value.trim();
-  const gps = gpsRaw.split(",").map(s => parseFloat(s.trim()));
-  if (gps.length !== 2 || gps.some(isNaN)) {
-    alert("Veuillez entrer des coordonnées valides au format : latitude, longitude");
+  const lat = parseFloat(document.getElementById("latitude").value);
+  const lon = parseFloat(document.getElementById("longitude").value);
+  if (isNaN(lat) || isNaN(lon)) {
+    alert("Veuillez entrer des coordonnées valides");
     return;
   }
 
@@ -36,7 +36,7 @@ document.getElementById("calculateIrrButton").addEventListener("click", async ()
   document.getElementById("facturean20").textContent = fr(facturean20);
 
   const angle = 28;
-  const url = `https://re.jrc.ec.europa.eu/api/v5_2/PVcalc?outputformat=basic&lat=${gps[0]}&lon=${gps[1]}&raddatabase=PVGIS-SARAH2&peakpower=1&loss=10&pvtechchoice=crystSi&angle=${angle}&aspect=${orientation}&usehorizon=1`;
+  const url = `https://re.jrc.ec.europa.eu/api/v5_2/PVcalc?outputformat=basic&lat=${lat}&lon=${lon}&raddatabase=PVGIS-SARAH2&peakpower=1&loss=10&pvtechchoice=crystSi&angle=${angle}&aspect=${orientation}&usehorizon=1`;
   const proxyUrl = `https://corsproxy.io/?url=${encodeURIComponent(url)}`;
 
   try {


### PR DESCRIPTION
## Summary
- Replace single GPS coordinate field with separate `latitude` and `longitude` inputs in HTML
- Update calculation script to read and validate latitude/longitude separately and build PVGIS URL accordingly

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d65a72b4832fbb11ff4a3ce55895